### PR TITLE
map on maybe nothing should be true for isNothing?

### DIFF
--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -79,13 +79,13 @@ class Nothing<A> extends Maybe<A> {
     return this;
   }
   map<B>(f: (a: A) => B): Maybe<B> {
-    return new Nothing<B>();
+    return nothing;
   }
   mapTo<B>(b: B): Maybe<B> {
-    return new Nothing<B>();
+    return nothing;
   }
   ap<B>(a: Maybe<(a: A) => B>): Maybe<B> {
-    return new Nothing<B>();
+    return nothing;
   }
   foldr<B>(f: (a: A, b: B) => B, acc: B): B {
     return acc;

--- a/test/maybe.ts
+++ b/test/maybe.ts
@@ -66,6 +66,9 @@ describe("Maybe", () => {
     // this should not throw a type error
     map<number, number>(x => x + 2, just(1)).chain(x => nothing);
   });
+  it("is still nothing after map on nothing", () => {
+    assert.strictEqual(isNothing(nothing.map(x => x * x)), true);
+  });
   it("works with mapTo", () => {
     assert.deepEqual(just(1), mapTo(1, just(2)));
   });


### PR DESCRIPTION
I was playing around with a ramda example and trying to learn by converting it to jabz [here](https://github.com/arlair/fp-jabz-playground/blob/master/jabz-version.ts#L40) and found the `map` on a `nothing` `maybe` constructs a new object, which then seems to fail because [`isNothing`](https://github.com/Funkia/jabz/blob/e78ddb0e60580acf120ad80749b6936cb22b37a0/src/maybe.ts#L82) [compares against the exported nothing object](https://github.com/Funkia/jabz/blob/e78ddb0e60580acf120ad80749b6936cb22b37a0/src/maybe.ts#L150) and it fails because they are different object versions of a `nothing`.

I tried creating a test and fixing it, but if it is not right, feel free to ignore or change it.